### PR TITLE
Update kfctl_ibm manifests to use Istio 1.3.1 (#1580)

### DIFF
--- a/kfdef/kfctl_ibm.v1.1.0.yaml
+++ b/kfdef/kfctl_ibm.v1.1.0.yaml
@@ -9,12 +9,12 @@ spec:
   - kustomizeConfig:
       repoRef:
         name: manifests
-        path: stacks/ibm/application/istio-stack
+        path: stacks/ibm/application/istio-1-3-1-stack
     name: istio-stack
   - kustomizeConfig:
       repoRef:
         name: manifests
-        path: stacks/ibm/application/cluster-local-gateway
+        path: stacks/ibm/application/cluster-local-gateway-1-3-1
     name: cluster-local-gateway
   - kustomizeConfig:
       repoRef:

--- a/kfdef/kfctl_ibm.yaml
+++ b/kfdef/kfctl_ibm.yaml
@@ -9,12 +9,12 @@ spec:
   - kustomizeConfig:
       repoRef:
         name: manifests
-        path: stacks/ibm/application/istio-stack
+        path: stacks/ibm/application/istio-1-3-1-stack
     name: istio-stack
   - kustomizeConfig:
       repoRef:
         name: manifests
-        path: stacks/ibm/application/cluster-local-gateway
+        path: stacks/ibm/application/cluster-local-gateway-1-3-1
     name: cluster-local-gateway
   - kustomizeConfig:
       repoRef:


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**


**Checklist:**
- [ ] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
